### PR TITLE
[FEATURE] #12 삭제 시 "그 외" 번호 수정

### DIFF
--- a/src/main/java/com/boa/conlog/ott/controller/OttController.java
+++ b/src/main/java/com/boa/conlog/ott/controller/OttController.java
@@ -85,6 +85,11 @@ public class OttController {
 
         ottService.deleteOtt(ottNo);
 
+        /* "그 외" 전 ott의 번호 불러온 후 "그 외"번호 수정 */
+        int lastSecondOttNo = ottService.findLastSecondOttNo();
+        int newEctOttNo = lastSecondOttNo + 1;
+        ottService.modifyEctOttNo(newEctOttNo);
+
         rttr.addFlashAttribute("successMessage", "OTT를 성공적으로 삭제했습니다.");
 
         return "redirect:/ott/list";

--- a/src/main/java/com/boa/conlog/ott/model/dao/OttMapper.java
+++ b/src/main/java/com/boa/conlog/ott/model/dao/OttMapper.java
@@ -28,4 +28,10 @@ public interface OttMapper {
 
     /* OTT 삭제 */
     void deleteOtt(int ottNo);
+
+    /* "그 외" 전 OTT 번호 불러오기 */
+    int findLastSecondOttNo();
+
+    /* "그 외" 번호 수정 */
+    void modifyEctOttNo(int newEctOttNo);
 }

--- a/src/main/java/com/boa/conlog/ott/model/service/OttService.java
+++ b/src/main/java/com/boa/conlog/ott/model/service/OttService.java
@@ -56,4 +56,15 @@ public class OttService {
 
         ottMapper.deleteOtt(ottNo);
     }
+
+    /* "그 외" 전 OTT 번호 불러오기 */
+    public int findLastSecondOttNo() {
+
+        return ottMapper.findLastSecondOttNo();
+    }
+
+    /* "그 외" 번호 수정 */
+    public void modifyEctOttNo(int newEctOttNo) {
+         ottMapper.modifyEctOttNo(newEctOttNo);
+    }
 }

--- a/src/main/resources/mappers/OttMapper.xml
+++ b/src/main/resources/mappers/OttMapper.xml
@@ -64,4 +64,20 @@
         DELETE FROM OTT
          WHERE OTT_NO = #{ ottNo }
     </delete>
+
+    <!-- "그 외" 전 번호 불러오기 -->
+    <select id="findLastSecondOttNo" resultType="_int">
+        SELECT
+               OTT_NO
+          FROM OTT
+         ORDER BY OTT_NO DESC
+         LIMIT 1, 1
+    </select>
+
+    <!-- "그 외" 번호 수정 -->
+    <update id="modifyEctOttNo" parameterType="_int">
+        UPDATE OTT
+           SET OTT_NO = #{ newEctOttNo }
+         WHERE OTT_NAME = "그 외"
+    </update>
 </mapper>


### PR DESCRIPTION
#12 

## 결과
![image](https://github.com/user-attachments/assets/25eb8a45-a7f2-46c7-a877-4eefca301640)
![image](https://github.com/user-attachments/assets/37dbf9d2-a5d0-41f2-8487-57367da8c575)

## 설명
수정 전에는 "바나나차차"를 삭제하면 바로 위 "라프텔" 번호 7과 "그 외" ottNo가 9 사이에 공백이 생깁니다.
미관 상 좋지 않아 연동된 숫자로 변경되게 수정했습니다.